### PR TITLE
fix issue with forwarding headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## tip
 
+* BUGFIX: fix issue with forwarding headers from datasource to the backend or proxy. 
+  It might be helpful if a user wants to use some kind of authentication. See [this issue](https://github.com/VictoriaMetrics/victorialogs-datasource/issues/54).
+
 ## [v0.8.4](https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/tag/v0.8.4)
 
 * BUGFIX: fix label join function in builder mode. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/162).

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -25,6 +25,8 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	if err != nil {
 		return nil, fmt.Errorf("http client options: %w", err)
 	}
+	opts.ForwardHTTPHeaders = true
+
 	cl, err := httpclient.New(opts)
 	if err != nil {
 		return nil, fmt.Errorf("httpclient new: %w", err)


### PR DESCRIPTION
If the user wants to use some OAuth and set the Forward OAuth Identity flag, headers with bearer tokens are not sent to the proxy server. This PR fixed this problem

Related issue: https://github.com/VictoriaMetrics/victorialogs-datasource/issues/54