### PR TITLE
Set default Type to instant for alert rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip 
 
+* FEATURE: set the default value of `Type` to `instant` when creating alerting rules. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/205).
+
 ## [v0.9.1](https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/tag/v0.9.1)
 
 * BUGFIX: fix parsing dots in the the `label_values` function in the query builder. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/198).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip 
 
-* FEATURE: set the default value of `Type` to `instant` when creating alerting rules. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/205).
+* FEATURE: set the default query type to `instant` when creating alerting rules. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/205).
 
 ## [v0.9.1](https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/tag/v0.9.1)
 

--- a/src/querybuilder/state.ts
+++ b/src/querybuilder/state.ts
@@ -42,7 +42,7 @@ export function getQueryWithDefaults(query: PromQuery, app: CoreApp | undefined)
     result = { ...query, editorMode: getDefaultEditorMode(query.expr) };
   }
 
-  if (query.expr == null) {
+  if (!query.expr) {
     result = { ...result, expr: '', legendFormat: LegendFormatMode.Auto };
   }
 
@@ -56,5 +56,10 @@ export function getQueryWithDefaults(query: PromQuery, app: CoreApp | undefined)
     }
   }
 
+  // Unified Alerting does not support "both" for query type – fall back to "range".
+  if (app === CoreApp.UnifiedAlerting) {
+    const isBothInstantAndRange = query.instant && query.range;
+    result = { ...result, range: isBothInstantAndRange, instant: !isBothInstantAndRange };
+  }
   return result;
 }


### PR DESCRIPTION

Set the default value of `Type` to `instant` when creating alerting rules. 

Related Issue: #205