### PR TITLE
Fixed health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * FEATURE: set the default query type to `instant` when creating alerting rules. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/205).
 
+* BUGFIX: removed `/select/`-prefixed part of path for /health endpoint requests. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/208).
+
 ## [v0.9.1](https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/tag/v0.9.1)
 
 * BUGFIX: fix parsing dots in the the `label_values` function in the query builder. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/198).

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -167,7 +168,14 @@ func (d *Datasource) query(ctx context.Context, query backend.DataQuery) backend
 // CheckHealth performs a request to the specified data source and returns an error if the HTTP handler did not return
 // a 200 OK response.
 func (d *Datasource) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	r, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s%s", d.settings.URL, health), nil)
+	endpoint := d.settings.URL
+	idx := strings.Index(endpoint, "/select/")
+	if idx > 0 {
+		endpoint = path.Join(endpoint[:idx], health)
+	} else {
+		endpoint = path.Join(endpoint, health)
+	}
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return newHealthCheckErrorf("could not create request"), nil
 	}


### PR DESCRIPTION
remove vmselect specific `/select/`-prefixed path part for /health endpoint requests. fixes https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/208