### PR TITLE
update dev process

### DIFF
--- a/.config/webpack/constants.ts
+++ b/.config/webpack/constants.ts
@@ -1,3 +1,3 @@
 export const SOURCE_DIR = 'src';
-export const DIST_DIR = 'victoriametrics-datasource';
+export const DIST_DIR = 'plugins/victoriametrics-datasource';
 export const ENTRY_FILE = `${SOURCE_DIR}/module.ts`;

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ work/
 ci/
 e2e-results/
 victoriametrics-datasource/
+plugins/
 packages/lezer-metricsql/src/parser.js
 packages/lezer-metricsql/src/parser.terms.js
 

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,18 @@ victoriametrics-datasource-plugin-build: \
 	victoriametrics-frontend-plugin-build \
 	victoriametrics-backend-plugin-build
 
-victoriametrics-datasource-plugin-pack:
-	tar -czf victoriametrics-datasource-$(PKG_TAG).tar.gz victoriametrics-datasource \
+victoriametrics-datasource-plugin-pack-tar:
+	tar -czf victoriametrics-datasource-$(PKG_TAG).tar.gz ./plugins/victoriametrics-datasource \
 	&& sha256sum victoriametrics-datasource-$(PKG_TAG).tar.gz \
-	> victoriametrics-datasource-$(PKG_TAG)_checksums.txt \
-	&& rm -rf ./victoriametrics-datasource
+	> victoriametrics-datasource-$(PKG_TAG)_checksums_tar.txt
+
+victoriametrics-datasource-plugin-pack-zip:
+	zip -r victoriametrics-datasource-$(PKG_TAG).zip ./plugins/victoriametrics-datasource \
+	&& sha256sum victoriametrics-datasource-$(PKG_TAG).zip \
+	> victoriametrics-datasource-$(PKG_TAG)_checksums_zip.txt
+
+victoriametrics-datasource-plugin-clean:
+	rm -rf ./plugin/victoriametrics-datasource
 
 victoriametrics-datasource-frontend-plugin-pack: \
 	frontend-pack
@@ -88,7 +95,9 @@ victoriametrics-datasource-frontend-plugin-release: \
 victoriametrics-datasource-plugin-release: \
 	victoriametrics-frontend-plugin-build \
 	victoriametrics-backend-plugin-build \
-	victoriametrics-datasource-plugin-pack
+	victoriametrics-datasource-plugin-pack-tar \
+	victoriametrics-datasource-plugin-pack-zip \
+	victoriametrics-datasource-plugin-clean
 
 build-release:
 	git checkout $(TAG) && $(MAKE) victoriametrics-datasource-plugin-release

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -38,7 +38,7 @@ app-via-docker: package-builder
 		go build $(RACE) -trimpath -buildvcs=false \
 			-ldflags "-extldflags '-static' $(GO_BUILDINFO)" \
 			-tags 'netgo osusergo nethttpomithttp2 musl' \
-			-o ./victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX) ./pkg/
+			-o ./plugins/victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX) ./pkg/
 
 app-via-docker-windows: package-builder
 	mkdir -p gocache-for-docker
@@ -52,7 +52,7 @@ app-via-docker-windows: package-builder
 		go build $(RACE) -trimpath -buildvcs=false \
 			-ldflags "-s -w -extldflags '-static' $(GO_BUILDINFO)" \
 			-tags 'netgo osusergo nethttpomithttp2' \
-			-o ./victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX).exe ./pkg/
+			-o ./plugins/victoriametrics-datasource/$(APP_NAME)$(APP_SUFFIX).exe ./pkg/
 
 frontend-package-base-image:
 	docker build -t frontent-builder-image -f deployment/docker/web/Dockerfile ./deployment/docker/web

--- a/package.json
+++ b/package.json
@@ -130,5 +130,6 @@
     "style-loader": "^3.3.1",
     "swc-loader": "^0.2.3",
     "ts-node": "^10.9.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -130,6 +130,5 @@
     "style-loader": "^3.3.1",
     "swc-loader": "^0.2.3",
     "ts-node": "^10.9.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -15,10 +15,10 @@ const config = (env) => {
   return merge(defaultConfig, {
     output: {
       clean: false,
-      path: path.resolve(__dirname, 'victoriametrics-datasource'),
+      path: path.resolve(__dirname, 'plugins/victoriametrics-datasource'),
       filename: '[name].js',
       // Keep publicPath relative for host.com/grafana/ deployments
-      publicPath: '/public/plugins/victoriametrics-datasource/',
+      publicPath: '/public/plugins/plugins/victoriametrics-datasource/',
     },
     resolve: {
       alias: {
@@ -44,7 +44,7 @@ const config = (env) => {
     plugins: [
       new CleanWebpackPlugin({
         cleanOnceBeforeBuildPatterns: [
-          path.join(__dirname, 'victoriametrics-datasource', '**/*.{js,css}'),
+          path.join(__dirname, 'plugins/victoriametrics-datasource', '**/*.{js,css}'),
         ],
         cleanAfterEveryBuildPatterns: [
           '!**/*.bin', // don't clear backend build


### PR DESCRIPTION
Starting from Grafana v10.4.0 it tries to check the folder inside the defined plugin folder.
If we set
plugins = /Users/path/victorialogs-datasource Grafana tries to check source plugins in the src folder and shows the error that the backend file can be found
But if we declare the path like
plugins = /Users/path/plugins/victorialogs-datasource (we create a folder above our plugin) it works correctly.

Also started from Grafana v10.4.0 when we started it and defined the plugin folder it added its own plugin named
grafana-lokiexplore-app

Those changes are compatible with the previous version of Grafana