### PR TITLE
Fix escaping in metrics browser selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* BUGFIX: fix escaping when selecting metrics in the metrics browser. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/214).
 
 ## [v0.10.2](https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/tag/v0.10.2)
 

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -64,10 +64,8 @@ import { mergeTemplateWithQuery } from "./components/WithTemplateConfig/utils/ge
 import { ANNOTATION_QUERY_STEP_DEFAULT, DATASOURCE_TYPE } from "./consts";
 import PrometheusLanguageProvider from './language_provider';
 import {
-  escapeMetricNameSpecialCharacters,
   expandRecordingRules,
   getVictoriaMetricsTime,
-  unescapeMetricNameSpecialCharacters
 } from './language_utils';
 import { renderLegendFormat } from './legend';
 import PrometheusMetricFindQuery from './metric_find_query';
@@ -1029,11 +1027,8 @@ export class PrometheusDatasource
     return this.templateSrv.getVariables().map((v) => `$${v.name}`);
   }
 
-  interpolateString(string: string) {
-    const operation = string.includes("__name__")
-      ? unescapeMetricNameSpecialCharacters
-      : escapeMetricNameSpecialCharacters;
-    return this.templateSrv.replace(operation(string), undefined, this.interpolateQueryExpr);
+  interpolateString(string: string, scopedVars?: ScopedVars) {
+    return this.templateSrv.replace(string, scopedVars, this.interpolateQueryExpr);
   }
 
   withTemplatesUpdate(withTemplates: WithTemplate[]) {


### PR DESCRIPTION
Excessive escaping of characters when selecting metrics in Metrics Browser has been fixed.

The queries contained unnecessary escape characters. For example, when selecting the label `bios_date` with the value `09/13/2024`, the query was formed as `{bios_date\="09\/13\/2024"}`, which led to errors. Now the queries are correctly formed as `{bios_date="09/13/2024"}`.

Related issue: #214