### PR TITLE
Fix incorrect step calculation for annotation queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## tip
 
+* BUGFIX: fix incorrect step calculation in annotation queries. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/217).
 
 ## [v0.10.2](https://github.com/VictoriaMetrics/victoriametrics-datasource/releases/tag/v0.10.2)
 

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -392,7 +392,7 @@ export class PrometheusDatasource
 
       if (request.targets.every(t => t.refId === "Anno")) {
         const query = { ...request.targets[0], expr: queries[0].expr } as PromQueryRequest
-        return this.performAnnotationQuery({ ...query, start, end })
+        return this.performAnnotationQuery({ ...query, start, end }, request.maxDataPoints);
       }
 
       // No valid targets, return the empty result to save a round trip.
@@ -716,7 +716,7 @@ export class PrometheusDatasource
     };
   };
 
-  performAnnotationQuery = (query: PromQueryRequest) => {
+  performAnnotationQuery = (query: PromQueryRequest, maxDataPoints?: number) => {
     const datasource = {
       uid: this.templateSrv.replace(query.datasource!.uid, {}),
       type: query.datasource!.type
@@ -728,7 +728,7 @@ export class PrometheusDatasource
         data: {
           from: (query.start * 1000).toString(),
           to: (query.end * 1000).toString(),
-          queries: [{ ...query, datasource, refId: "X" }],
+          queries: [{ ...query, datasource, refId: "X", maxDataPoints }],
         },
         requestId: query.requestId,
       }).pipe(


### PR DESCRIPTION
This PR resolves an issue where the `step` for returned results in annotation queries was calculated incorrectly, resulting in missed events. The issue was caused by the absence of the `maxDataPoints` parameter.

Related issue: #217