### PR TITLE
Fix issue with lezer-metricsql dependency and public folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix issue with including the lezer-metricsql package to the build and fix public folder. See [this PR](https://github.com/VictoriaMetrics/victoriametrics-datasource/pull/256).
+
 ## v0.12.0
 
 ⚠️ **Breaking Change: Plugin ID Updated**  

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ frontend-build: frontend-package-base-image
 		--user $(shell id -u):$(shell id -g) \
 		--env YARN_CACHE_FOLDER="/victoriametrics-datasource/.cache" \
 		--entrypoint=/bin/bash \
-		frontent-builder-image -c "yarn install --omit=dev && yarn build"
+		frontent-builder-image -c "yarn preinstall && yarn install --omit=dev && yarn build"
 
 app-via-docker-local:
 	$(eval OS := $(shell docker run $(GO_BUILDER_IMAGE) go env GOOS))

--- a/packages/lezer-metricsql/package.json
+++ b/packages/lezer-metricsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lezer-metricsql",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "index.cjs",
   "type": "module",
   "exports": {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -18,7 +18,7 @@ const config = (env) => {
       path: path.resolve(__dirname, 'plugins/victoriametrics-metrics-datasource'),
       filename: '[name].js',
       // Keep publicPath relative for host.com/grafana/ deployments
-      publicPath: '/public/plugins/plugins/victoriametrics-metrics-datasource/',
+      publicPath: '/public/plugins/victoriametrics-metrics-datasource/',
     },
     resolve: {
       alias: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,7 +7101,7 @@ levn@^0.4.1:
     type-check "~0.4.0"
 
 "lezer-metricsql@file:packages/lezer-metricsql":
-  version "0.1.4"
+  version "0.1.5"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"


### PR DESCRIPTION
This PR fixed the issue with the frontend dependency. 
Before this fix lezer-metricsql was not included in the dependencies and Grafana shows an error. 

<img width="1799" alt="Screenshot 2025-01-23 at 16 37 36" src="https://github.com/user-attachments/assets/d8d50527-8131-49ab-93b4-273c49d4a08e" />
