### PR TITLE
backend: switch INFO logs to DEBUG level

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	backend.Logger.Info("Starting VictoriaMetrics datasource backend ...")
+	backend.Logger.Debug("Starting VictoriaMetrics datasource backend ...")
 
 	if err := datasource.Manage("victoriametrics-metrics-datasource", plugin.NewDatasource, datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error("Failed to process VictoriaMetrics datasource backend :%s", err.Error())


### PR DESCRIPTION
This should reduce pollution in Grafana logs,
as suggested during plugin review for Grafana marketplace.