### PR TITLE
Fix issue with default instant query for the alert panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: correctly calculate step for the instant query, use `5m` step for the alerting queries if interval wasn't explicitly set by user. This change reduces alerts flapping for Grafana managed alerts. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/276).
+
 ## v0.13.2
 
 * BUGFIX: use `5m` step for the alerting queries if interval wasn't explicitly set by user. This change reduces alerts flapping for Grafana managed alerts. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/276). 

--- a/pkg/plugin/step.go
+++ b/pkg/plugin/step.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	varInterval     = "$__interval"
-	varIntervalMs   = "$__interval_ms"
-	varRange        = "$__range"
-	varRangeS       = "$__range_s"
-	varRangeMs      = "$__range_ms"
-	varRateInterval = "$__rate_interval"
+	varInterval            = "$__interval"
+	varIntervalMs          = "$__interval_ms"
+	varRange               = "$__range"
+	varRangeS              = "$__range_s"
+	varRangeMs             = "$__range_ms"
+	varRateInterval        = "$__rate_interval"
+	defaultIntervalMsValue = 1000
 )
 
 var (
@@ -37,6 +38,9 @@ func (q *Query) getIntervalFrom(defaultInterval time.Duration) (time.Duration, e
 		interval = ""
 	}
 	if interval == "" {
+		if q.IntervalMs == defaultIntervalMsValue && q.Instant {
+			return instantQueryDefaultStep, nil
+		}
 		if q.IntervalMs != 0 {
 			return time.Duration(q.IntervalMs) * time.Millisecond, nil
 		}

--- a/pkg/plugin/step_test.go
+++ b/pkg/plugin/step_test.go
@@ -229,6 +229,20 @@ func Test_calculateStep(t *testing.T) {
 			},
 			want: "10s",
 		},
+		{
+			name: "instant query with default values",
+			query: &Query{
+				Instant:       true,
+				MaxDataPoints: 43200,
+				TimeRange: TimeRange{
+					From: time.Now().Add(-time.Hour * 24 * 90),
+					To:   time.Now(),
+				},
+				IntervalMs: 1000,
+				Interval:   "",
+			},
+			want: "5m0s",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixed all possible combinations of the instant query. 
correctly calculate step for the instant query, use `5m` step for the alerting queries if interval wasn't explicitly set by user. This change reduces alerts flapping for Grafana managed alerts.