### PR TITLE
Fix error when response detected as not a wide series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix error when response detected as not a wide series. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/286).
+
 ## v0.13.3
 
 * BUGFIX: correctly calculate step for the instant query, use `5m` step for the alerting queries if interval wasn't explicitly set by user. This change reduces alerts flapping for Grafana managed alerts. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/276).

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -72,6 +72,10 @@ func (pi *promInstant) alertingDataFrames() (data.Frames, error) {
 
 		frames[i] = data.NewFrame("",
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels(res.Labels), []float64{f}))
+
+		// to show instant alert response with the table we need to define the type of the frame
+		// and it should be [0, 1] like it set in the Grafana
+		frames[i].Meta = &data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}
 	}
 
 	return frames, nil

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"reflect"
+	"bytes"
 	"testing"
 	"time"
 
@@ -136,10 +136,10 @@ func TestResponse_getDataFrames(t *testing.T) {
 				return []*data.Frame{
 					data.NewFrame("",
 						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "vm_rows"}, []float64{13763}),
-					),
+					).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
 					data.NewFrame("",
 						data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "vm_requests"}, []float64{2000}),
-					),
+					).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericMulti, TypeVersion: data.FrameTypeVersion{0, 1}}),
 				}
 			},
 			wantErr: false,
@@ -166,8 +166,19 @@ func TestResponse_getDataFrames(t *testing.T) {
 				tt.query.addMetadataToMultiFrame(got[i])
 			}
 
-			if !reflect.DeepEqual(got, w) {
-				t.Errorf("getDataFrames() got = %v, want %v", got, w)
+			gotResponse, err := got.MarshalJSON()
+			if err != nil {
+				t.Errorf("getDataFrames() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			wResponse, err := w.MarshalJSON()
+			if err != nil {
+				t.Errorf("getDataFrames() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !bytes.EqualFold(gotResponse, wResponse) {
+				t.Errorf("getDataFrames() = %s, want %s", gotResponse, wResponse)
 			}
 		})
 	}


### PR DESCRIPTION
Fixed problem when series was detected as not a wide series. It was happened because reponse had a typeInfo as [0, 0] instead of [0, 1].

See this [comment](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/286#issuecomment-2679231412) with the explanation.

Related issue: https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/286