### PR TITLE
Automatically escape metric and label names in the query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: automatically escape metric and label names in the query builder. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/266).
+
 ## v0.13.4
 
 * BUGFIX: fix error when response detected as not a wide series. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/286).

--- a/packages/lezer-metricsql/package.json
+++ b/packages/lezer-metricsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lezer-metricsql",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "index.cjs",
   "type": "module",
   "exports": {

--- a/packages/lezer-metricsql/src/metricsql.grammar
+++ b/packages/lezer-metricsql/src/metricsql.grammar
@@ -364,8 +364,8 @@ AtModifierPreprocessors {
   Start | End
 }
 
-NumberLiteral  {
- ("-"|"+")?~signed (number | inf | nan)
+NumberLiteral {
+  ("-"|"+")?~signed (number | inf | nan)
 }
 
 @skip { whitespace | LineComment }
@@ -395,12 +395,17 @@ NumberLiteral  {
     ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" ) ( std.digit+ "ms" )? ) |
     ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" ) )
   }
-  EscapedChar {("\\" AnyEscapesChar) ("\\" AnyEscapesChar)*}
-  AnyEscapesChar { "-" | "+" | "*" | "/" | "%" | "^" | "=" }
-  Identifier {(std.asciiLetter | "_" | ":" | "." | EscapedChar) (std.asciiLetter | std.digit | "_" | ":" | "." | "-" | EscapedChar)*}
-  LabelName {(std.asciiLetter | "_" | ":" | "." | EscapedChar) (std.asciiLetter | std.digit | "_" | ":" | "." | "-" | EscapedChar)*}
 
-  // Operator
+  // Modified EscapedChar: match a '\' followed by any single character using the wildcard.
+  EscapedChar { "\\" _ }
+
+  // Identifier: first character allowed: std.asciiLetter, "_" or ":" or an EscapedChar.
+  // Subsequent characters allowed: std.asciiLetter, std.digit, "_" , ":" or "." or "-" or an EscapedChar.
+  Identifier { (std.asciiLetter | "_" | ":" | EscapedChar) (std.asciiLetter | std.digit | "_" | ":" | "." | "-" | EscapedChar)* }
+
+  // LabelName: same as Identifier.
+  LabelName { (std.asciiLetter | "_" | ":" | EscapedChar) (std.asciiLetter | std.digit | "_" | ":" | "." | "-" | EscapedChar)* }
+
   Sub { "-" }
   Add { "+" }
   Mul { "*" }
@@ -468,17 +473,17 @@ NumberLiteral  {
   Acos { condFn<"acos"> }
   Acosh { condFn<"acosh"> }
   Asin { condFn<"asin"> }
-  Asinh { condFn<"asinh">}
+  Asinh { condFn<"asinh"> }
   Atan { condFn<"atan"> }
-  Atanh { condFn<"atanh">}
+  Atanh { condFn<"atanh"> }
   AvgOverTime { condFn<"avg_over_time"> }
   Ceil { condFn<"ceil"> }
   Changes { condFn<"changes"> }
   Clamp { condFn<"clamp"> }
   ClampMax { condFn<"clamp_max"> }
   ClampMin { condFn<"clamp_min"> }
-  Cos { condFn<"cos">}
-  Cosh { condFn<"cosh">}
+  Cos { condFn<"cos"> }
+  Cosh { condFn<"cosh"> }
   CountOverTime { condFn<"count_over_time"> }
   DaysInMonth { condFn<"days_in_month"> }
   DayOfMonth { condFn<"day_of_month"> }
@@ -497,7 +502,7 @@ NumberLiteral  {
   Irate { condFn<"irate"> }
   LabelReplace { condFn<"label_replace"> }
   LabelJoin { condFn<"label_join"> }
-  LastOverTime {condFn<"last_over_time">}
+  LastOverTime { condFn<"last_over_time"> }
   Ln { condFn<"ln"> }
   Log10 { condFn<"log10"> }
   Log2 { condFn<"log2"> }
@@ -505,7 +510,7 @@ NumberLiteral  {
   MinOverTime { condFn<"min_over_time"> }
   Minute { condFn<"minute"> }
   Month { condFn<"month"> }
-  Pi { condFn<"pi">}
+  Pi { condFn<"pi"> }
   PredictLinear { condFn<"predict_linear"> }
   PresentOverTime { condFn<"present_over_time"> }
   QuantileOverTime { condFn<"quantile_over_time"> }
@@ -515,7 +520,7 @@ NumberLiteral  {
   Round { condFn<"round"> }
   Scalar { condFn<"scalar"> }
   Sgn { condFn<"sgn"> }
-  Sin { condFn<"sin">}
+  Sin { condFn<"sin"> }
   Sinh { condFn<"sinh"> }
   Sort { condFn<"sort"> }
   SortDesc { condFn<"sort_desc"> }
@@ -524,7 +529,7 @@ NumberLiteral  {
   StdvarOverTime { condFn<"stdvar_over_time"> }
   SumOverTime { condFn<"sum_over_time"> }
   Tan { condFn<"tan"> }
-  Tanh { condFn<"tanh">}
+  Tanh { condFn<"tanh"> }
   Time { condFn<"time"> }
   Timestamp { condFn<"timestamp"> }
   Vector { condFn<"vector"> }

--- a/src/language_utils.test.ts
+++ b/src/language_utils.test.ts
@@ -3,6 +3,8 @@ import { AbstractLabelOperator, AbstractQuery } from '@grafana/data';
 import {
   escapeLabelValueInExactSelector,
   escapeLabelValueInRegexSelector,
+  escapeMetricNameSpecialCharacters,
+  escapeIdentifier,
   expandRecordingRules,
   fixSummariesMetadata,
   parseSelector,
@@ -219,6 +221,55 @@ describe('escapeLabelValueInRegexSelector()', () => {
     expect(escapeLabelValueInRegexSelector('t\\e"s+t\nl\n$ab"e\\l')).toBe(
       't\\\\\\\\e\\"s\\\\+t\\nl\\n\\\\$ab\\"e\\\\\\\\l'
     );
+  });
+});
+
+describe('escapeMetricNameSpecialCharacters()', () => {
+  it('should escape a metric name starting with a digit', () => {
+    // "3foo" should become "\3foo"
+    expect(escapeMetricNameSpecialCharacters("3foo")).toBe("\\3foo");
+  });
+
+  it('should escape special characters in metric names', () => {
+    // For example, "3foo(b)ar" becomes "\3foo\(b\)ar"
+    expect(escapeMetricNameSpecialCharacters("3foo(b)ar")).toBe("\\3foo\\(b\\)ar");
+    // And "metric+test" becomes "metric\+test"
+    expect(escapeMetricNameSpecialCharacters("metric+test")).toBe("metric\\+test");
+  });
+
+  it('should not modify valid metric names', () => {
+    expect(escapeMetricNameSpecialCharacters("foo_bar:metric")).toBe("foo_bar:metric");
+    expect(escapeMetricNameSpecialCharacters("metric.name")).toBe("metric.name");
+  });
+
+  it('should escape UTF-8 metric names', () => {
+    // For example, "3fooµ¥" should become "\3foo\µ\¥"
+    expect(escapeMetricNameSpecialCharacters("3fooµ¥")).toBe("\\3foo\\µ\\¥");
+  });
+});
+
+describe('escapeIdentifier() used for label names', () => {
+  it('should escape a label name starting with a digit', () => {
+    // "3label" should become "\3label"
+    expect(escapeIdentifier("3label")).toBe("\\3label");
+  });
+
+  it('should escape special characters in label names', () => {
+    // For example, "3label(b)name" should become "\3label\(b\)name"
+    expect(escapeIdentifier("3label(b)name")).toBe("\\3label\\(b\\)name");
+    // And "label+test" should become "label\+test"
+    expect(escapeIdentifier("label+test")).toBe("label\\+test");
+  });
+
+  it('should not modify valid label names', () => {
+    expect(escapeIdentifier("label_name")).toBe("label_name");
+    expect(escapeIdentifier("label:name")).toBe("label:name");
+  });
+
+  it('should escape UTF-8 label names', () => {
+    // For example, "3👋tfにちは" should become "\3\👋tf\に\ち\は"
+    // (All non-ASCII characters are escaped by our logic.)
+    expect(escapeIdentifier("3👋tfにちは")).toBe("\\3\\👋tf\\に\\ち\\は");
   });
 });
 

--- a/src/querybuilder/components/PromQueryBuilder.tsx
+++ b/src/querybuilder/components/PromQueryBuilder.tsx
@@ -105,7 +105,7 @@ export const PromQueryBuilder = React.memo<Props>((props) => {
     const expr = promQueryModeller.renderLabels(labelsToConsider);
     const result = await datasource.languageProvider.fetchSeriesLabels(expr);
     const forLabelInterpolated = datasource.interpolateString(forLabel.label);
-    return result[forLabelInterpolated].map((v) => ({ value: v })) ?? [];
+    return result[forLabelInterpolated]?.map((v) => ({ value: v })) ?? [];
   };
 
   const onGetMetrics = useCallback(() => {

--- a/src/querybuilder/shared/LabelFilterItem.tsx
+++ b/src/querybuilder/shared/LabelFilterItem.tsx
@@ -24,6 +24,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Select } from '@grafana/ui';
 
 import { AccessoryButton, InputGroup } from '../../components/QueryEditor';
+import { escapeIdentifier } from "../../language_utils";
 
 import { QueryBuilderLabelFilter } from './types';
 
@@ -88,7 +89,7 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
               onChange({
                 ...item,
                 op: item.op ?? defaultOp,
-                label: change.label,
+                label: escapeIdentifier(change.label),
               } as any as QueryBuilderLabelFilter);
             }
           }}


### PR DESCRIPTION
Automatically escape metric and label names in the query builder so that names with special characters (e.g. "3foo(b)ar") are handled correctly.

Related issue: #266