### PR TITLE
fix incorrect vmui link address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * FEATURE: automatically escape metric and label names in the query builder. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/266).
 
+* BUGFIX: fix an issue where the `vmui` link had an incorrect address of the type `about:blank`. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/288).
+
 ## v0.13.4
 
 * BUGFIX: fix error when response detected as not a wide series. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/286).


### PR DESCRIPTION
This PR fixes an issue where the VMUI link was incorrectly set to `about:blank`. 
Related issue: #288