### PR TITLE
Fix special char handling in metrics and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: add support dots in label name. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/205).
+
 ## v0.15.1
 
 * Added PDC support. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5624).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * FEATURE: add support dots in label name. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/205).
 
+* BUGFIX: fix label filter value loading for metric names with special characters. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/131).
+
 ## v0.15.1
 
 * Added PDC support. See [this issue](https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5624).

--- a/src/language_provider.ts
+++ b/src/language_provider.ts
@@ -557,7 +557,8 @@ export default class PromQlLanguageProvider extends LanguageProvider {
    * @param withName
    */
   fetchSeriesLabels = async (name: string, withName?: boolean): Promise<Record<string, string[]>> => {
-    const interpolatedName = this.datasource.interpolateString(name);
+    const unescapedName = name.replace(/\\(.)/g, '$1')
+    const interpolatedName = this.datasource.interpolateString(unescapedName);
     const range = this.datasource.getTimeRangeParams();
     const limit = this.datasource.getLimitMetrics('maxSeries');
     const urlParams = {

--- a/src/metricsql.ts
+++ b/src/metricsql.ts
@@ -1322,7 +1322,7 @@ export const metricsqlGrammar: Grammar = {
         pattern: /#.*/,
       },
       'label-key': {
-        pattern: /[a-z_]\w*(?=\s*(=|!=|=~|!~))/,
+        pattern: /[a-z_][\w.]*(?=\s*(=|!=|=~|!~))/,
         alias: 'attr-name',
         greedy: true,
       },


### PR DESCRIPTION
- Fixed incorrect label filter behavior for metric names with special characters. Related issue: #131
- Enabled support for dot characters in label names. Related issue: #205