### PR TITLE
fix issue in Grafana 10.1.5 where creating a variable using label_values is not possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FEATURE: add support dots in label name. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/205).
 
 * BUGFIX: fix label filter value loading for metric names with special characters. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/131).
+* BUGFIX: fix an issue in Grafana 10.1.5 where creating a variable using label_values is not possible .See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/319).
 
 ## v0.15.1
 

--- a/src/querybuilder/components/LabelFilters.tsx
+++ b/src/querybuilder/components/LabelFilters.tsx
@@ -20,9 +20,10 @@ import { isEqual } from 'lodash';
 import React, { useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorFieldGroup, EditorField, EditorList } from '@grafana/plugin-ui';
+import { EditorFieldGroup, EditorField } from '@grafana/plugin-ui';
 import { InlineFieldRow, InlineLabel } from '@grafana/ui';
 
+import { EditorList } from "../../components/QueryEditor";
 import { QueryBuilderLabelFilter } from '../shared/types';
 
 import { LabelFilterItem } from './LabelFilterItem';


### PR DESCRIPTION
Related isuue: #319 

Problem was in grafana's component `Stack`, so just changed the grafana's `EditorList` to datasource implementation of `EditorList` component.