### PR TITLE
add a rollup field to rollup_rate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * BUGFIX: fix label filter value loading for metric names with special characters. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/131).
 * BUGFIX: fix an issue in Grafana 10.1.5 where creating a variable using label_values is not possible. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/319).
+* BUGFIX: add a rollup field to rollup_rate function. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/316).
 
 ## v0.15.1
 

--- a/src/querybuilder/aggregations.ts
+++ b/src/querybuilder/aggregations.ts
@@ -6,7 +6,7 @@ import {
   getRangeVectorParamDef,
 } from './shared/operationUtils';
 import { QueryBuilderOperation, QueryBuilderOperationDef } from './shared/types';
-import { PromVisualQueryOperationCategory, PromOperationId } from './types';
+import { PromOperationId, PromVisualQueryOperationCategory } from './types';
 
 export function getAggregationOperations(): QueryBuilderOperationDef[] {
   return [
@@ -42,7 +42,10 @@ export function getAggregationOperations(): QueryBuilderOperationDef[] {
   ];
 }
 
-export function createAggregationOverTime(name: string): QueryBuilderOperationDef {
+export function createAggregationOverTime(
+  name: string,
+  override: Partial<QueryBuilderOperationDef> = {},
+): QueryBuilderOperationDef {
   return {
     id: name,
     name: getPromAndLokiOperationDisplayName(name),
@@ -52,6 +55,7 @@ export function createAggregationOverTime(name: string): QueryBuilderOperationDe
     category: PromVisualQueryOperationCategory.RangeFunctions,
     renderer: operationWithRangeVectorRenderer,
     addOperationHandler: addOperationWithRangeVector,
+    ...override
   };
 }
 

--- a/src/querybuilder/metricsql-functions/aggregations/overTime.ts
+++ b/src/querybuilder/metricsql-functions/aggregations/overTime.ts
@@ -1,54 +1,92 @@
 import { createAggregationOverTime } from "../../aggregations";
+import { getRangeVectorParamDef } from "../../shared/operationUtils";
+import { QueryBuilderOperation, QueryBuilderOperationDef } from "../../shared/types";
 import { PromOperationId } from "../../types";
 
-const overTimeFunctions = [
-  PromOperationId.AscentOverTime,
-  PromOperationId.ChangesPrometheus,
-  PromOperationId.DecreasesOverTime,
-  PromOperationId.DefaultRollup,
-  PromOperationId.DeltaPrometheus,
-  PromOperationId.DerivFast,
-  PromOperationId.DescentOverTime,
-  PromOperationId.DistinctOverTime,
-  PromOperationId.FirstOverTime,
-  PromOperationId.GeomeanOverTime,
-  PromOperationId.HistogramOverTime,
-  PromOperationId.Ideriv,
-  PromOperationId.IncreasePrometheus,
-  PromOperationId.IncreasePure,
-  PromOperationId.IncreasesOverTime,
-  PromOperationId.Integrate,
-  PromOperationId.Lag,
-  PromOperationId.Lifetime,
-  PromOperationId.MadOverTime,
-  PromOperationId.MedianOverTime,
-  PromOperationId.ModeOverTime,
-  PromOperationId.RangeOverTime,
-  PromOperationId.RateOverSum,
-  PromOperationId.Rollup,
-  PromOperationId.RollupCandlestick,
-  PromOperationId.RollupDelta,
-  PromOperationId.RollupDeriv,
-  PromOperationId.RollupIncrease,
-  PromOperationId.RollupRate,
-  PromOperationId.RollupScrapeInterval,
-  PromOperationId.ScrapeInterval,
-  PromOperationId.StaleSamplesOverTime,
-  PromOperationId.StdvarOverTime,
-  PromOperationId.Sum2OverTime,
-  PromOperationId.TimestampWithName,
-  PromOperationId.TfirstOverTime,
-  PromOperationId.TlastChangeOverTime,
-  PromOperationId.TlastOverTime,
-  PromOperationId.TmaxOverTime,
-  PromOperationId.TminOverTime,
-  PromOperationId.ZscoreOverTime,
-  PromOperationId.HistogramAvg,
-  PromOperationId.HistogramStddev,
-  PromOperationId.HistogramStdvar,
-  PromOperationId.PrometheusBuckets,
-]
-
 export function getOverTimeFunctions() {
-  return overTimeFunctions.map(id => createAggregationOverTime(id))
+  return [
+    ...[
+      PromOperationId.AscentOverTime,
+      PromOperationId.ChangesPrometheus,
+      PromOperationId.DecreasesOverTime,
+      PromOperationId.DefaultRollup,
+      PromOperationId.DeltaPrometheus,
+      PromOperationId.DerivFast,
+      PromOperationId.DescentOverTime,
+      PromOperationId.DistinctOverTime,
+      PromOperationId.FirstOverTime,
+      PromOperationId.GeomeanOverTime,
+      PromOperationId.HistogramOverTime,
+      PromOperationId.Ideriv,
+      PromOperationId.IncreasePrometheus,
+      PromOperationId.IncreasePure,
+      PromOperationId.IncreasesOverTime,
+      PromOperationId.Integrate,
+      PromOperationId.Lag,
+      PromOperationId.Lifetime,
+      PromOperationId.MadOverTime,
+      PromOperationId.MedianOverTime,
+      PromOperationId.ModeOverTime,
+      PromOperationId.RangeOverTime,
+      PromOperationId.RateOverSum,
+      PromOperationId.Rollup,
+      PromOperationId.RollupCandlestick,
+      PromOperationId.RollupDelta,
+      PromOperationId.RollupDeriv,
+      PromOperationId.RollupIncrease
+    ].map(id => createAggregationOverTime(id)),
+
+    createAggregationOverTime(
+      PromOperationId.RollupRate,
+      {
+        params: [getRangeVectorParamDef(), {
+          name: 'Rollup',
+          type: 'string',
+          optional: true,
+          options: [
+            { label: 'min', value: 'min' },
+            { label: 'max', value: 'max' },
+            { label: 'avg', value: 'avg' },
+          ],
+        }],
+        defaultParams: ['$__interval', ''],
+        renderer: rollupRateRenderer
+      }
+    ),
+
+    ...[
+      PromOperationId.RollupScrapeInterval,
+      PromOperationId.ScrapeInterval,
+      PromOperationId.StaleSamplesOverTime,
+      PromOperationId.StdvarOverTime,
+      PromOperationId.Sum2OverTime,
+      PromOperationId.TimestampWithName,
+      PromOperationId.TfirstOverTime,
+      PromOperationId.TlastChangeOverTime,
+      PromOperationId.TlastOverTime,
+      PromOperationId.TmaxOverTime,
+      PromOperationId.TminOverTime,
+      PromOperationId.ZscoreOverTime,
+      PromOperationId.HistogramAvg,
+      PromOperationId.HistogramStddev,
+      PromOperationId.HistogramStdvar,
+      PromOperationId.PrometheusBuckets,
+    ].map(id => createAggregationOverTime(id)),
+  ]
+}
+
+export const overTimeFunctionNames = getOverTimeFunctions().map(({ id }) => id);
+
+function rollupRateRenderer(
+  model: QueryBuilderOperation,
+  def: QueryBuilderOperationDef,
+  innerExpr: string
+) {
+  let rangeVector = model.params?.[0] ?? '$__interval';
+  const args = [`${innerExpr}[${rangeVector}]`];
+  const rollupParam = model.params?.[1];
+  if (rollupParam) {
+    args.push(`"${rollupParam}"`);
+  }
+  return `${def.id}(${args.join(', ')})`;
 }

--- a/src/querybuilder/parsing.ts
+++ b/src/querybuilder/parsing.ts
@@ -28,6 +28,7 @@ import {
 } from 'lezer-metricsql';
 
 import { binaryScalarOperatorToOperatorName } from './binaryScalarOperations';
+import { overTimeFunctionNames }  from "./metricsql-functions/aggregations/overTime";
 import {
   ErrorId,
   ErrorName,
@@ -195,7 +196,7 @@ function getLabel(
   };
 }
 
-const rangeFunctions = ['changes', 'rate', 'irate', 'increase', 'delta'];
+const rangeFunctions = ['changes', 'rate', 'irate', 'increase', 'delta', ...overTimeFunctionNames];
 
 /**
  * Handle function call which is usually and identifier and its body > arguments.


### PR DESCRIPTION
Related issue: #316 
- added a rollup field to rollup_rate function
- fixed parsing of over_time functions 