### PR TITLE
bump Grafana minimum supported version to 10.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BREAKING: increase minimum required Grafana version to `>=10.4.0` to ensure compatibility with [`@grafana/plugin-ui`](https://github.com/grafana/plugin-ui). This drops support for older Grafana versions.
+
 * FEATURE: add support for the `default` binary operator in the visual query builder. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/296).
 
 * BUGFIX: add a rollup field to rollup_rate function. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/316).

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -102,7 +102,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=8.3.0",
+    "grafanaDependency": ">=10.4.0",
     "plugins": []
   }
 }


### PR DESCRIPTION
Updates `grafanaDependency` to `>=10.4.0` for compatibility with [@grafana/plugin-ui](https://github.com/grafana/plugin-ui).

This change drops support for Grafana versions earlier than `10.4.0`, so a major version bump of the plugin is recommended.
