### PR TITLE
fix incorrect field unmarshalling when rendering query results as a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix incorrect field unmarshalling when rendering query results as a table. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/354)
+
 ## v0.18.3
 
 * BUGFIX: fix the calculation of the `step` parameter and lookbehind window for the `range` queries if the `$__rate_interval` variable is used. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/347).


### PR DESCRIPTION
Related issue: #354 
Fixed incorrect field unmarshalling when rendering query results as a table. 