### PR TITLE
fix issue with concurrent map writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FEATURE: upgrade Go builder from Go1.24.2 to Go1.25. See [Go1.25 release notes](https://tip.golang.org/doc/go1.25).
 
 * BUGFIX: fix incorrect field unmarshalling when rendering query results as a table. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/354)
+* BUGFIX: fix issue with concurrent map writes when performing multiple requests to the datasource. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/363)
 
 ## v0.18.3
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -167,11 +167,15 @@ func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReques
 	}
 
 	var wg sync.WaitGroup
+	var mu sync.Mutex
 	for _, q := range req.Queries {
 		wg.Add(1)
 		go func(q backend.DataQuery, forAlerting bool) {
 			defer wg.Done()
-			response.Responses[q.RefID] = di.query(ctx, q, forAlerting)
+			resp := di.query(ctx, q, forAlerting)
+			mu.Lock()
+			response.Responses[q.RefID] = resp
+			mu.Unlock()
 		}(q, forAlerting)
 	}
 	wg.Wait()


### PR DESCRIPTION
Fixed concurrent map writes when performing multiple requests 

Related issue: #363 