### PR TITLE
fix an issue where line charts were incorrectly connecting data points across missing (null) values despite the "Connect null values" panel setting being set to "Never"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * BUGFIX: fix the calculation of the `step` parameter and lookbehind window for the `range` queries if the `$__rate_interval` variable is used. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/347).
 * BUGFIX: fix parsing of the datasource settings, enable usage of the scrape interval when the lookbehind window is calculated for the query url. See [this PR](https://github.com/VictoriaMetrics/victoriametrics-datasource/pull/349).
 * BUGFIX: fix handling of the 'auto' legend mode so series labels are generated correctly. See [this issue](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/350).
+* BUGFIX: fix an issue where line charts were incorrectly connecting data points across missing (null) values despite the "Connect null values" panel setting being set to "Never". See [#364](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/364).
 
 ## v0.18.2
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -253,6 +253,7 @@ func (di *DatasourceInstance) query(ctx context.Context, query backend.DataQuery
 	}
 	for i := range frames {
 		q.addMetadataToMultiFrame(frames[i])
+		q.addIntervalToFrame(frames[i])
 	}
 
 	return backend.DataResponse{Frames: frames}

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -153,6 +153,15 @@ func (q *Query) addMetadataToMultiFrame(frame *data.Frame) {
 	frame.Name = customName
 }
 
+func (q *Query) addIntervalToFrame(frame *data.Frame) {
+	if len(frame.Fields) > 0 && q.IntervalMs > 0 {
+		if frame.Fields[0].Config == nil {
+			frame.Fields[0].Config = &data.FieldConfig{}
+		}
+		frame.Fields[0].Config.Interval = float64(q.IntervalMs)
+	}
+}
+
 func labelsToString(labels data.Labels) string {
 	if labels == nil || len(labels) < 1 {
 		return "{}"


### PR DESCRIPTION
Related issue: #364 

Fixed an issue where line charts were incorrectly connecting data points across missing (null) values despite the "Connect null values" panel setting being set to "Never" by setting the interval value in field config
<img width="1195" height="633" alt="image" src="https://github.com/user-attachments/assets/2ca7b4dd-4ada-43af-8623-fb0b75981f38" />
