### PR TITLE
fix unpredictable behavior when determining an interval for a range query 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix unpredictable behavior when determining an interval for a range query. See [#383](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/383)
+
 ## v0.19.2
 
 * BUGFIX: fix the issue with dashboards showing no data when the `format` field was undefined. Now the `format` defaults to `time_series` when not explicitly set, ensuring proper data visualization for existing queries and dashboards. See [#377](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/377)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip
 
-* BUGFIX: fix unpredictable behavior when determining an interval for a range query. See [#383](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/383)
+* BUGFIX: auto-calculate `step` param for a range queries consistently with other datasources. Before, `step` between datapoints on the graph could have use unexpected values depending on the time range. See [#383](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/383)
 
 ## v0.19.2
 

--- a/pkg/plugin/step.go
+++ b/pkg/plugin/step.go
@@ -182,88 +182,88 @@ func roundInterval(interval time.Duration) time.Duration {
 	case interval <= 10*time.Millisecond:
 		return time.Millisecond * 1 // 0.001s
 	// 0.015s
-	case interval <= 15*time.Millisecond:
+	case interval < 15*time.Millisecond:
 		return time.Millisecond * 10 // 0.01s
 	// 0.035s
-	case interval <= 35*time.Millisecond:
+	case interval < 35*time.Millisecond:
 		return time.Millisecond * 20 // 0.02s
 	// 0.075s
-	case interval <= 75*time.Millisecond:
+	case interval < 75*time.Millisecond:
 		return time.Millisecond * 50 // 0.05s
 	// 0.15s
-	case interval <= 150*time.Millisecond:
+	case interval < 150*time.Millisecond:
 		return time.Millisecond * 100 // 0.1s
 	// 0.35s
-	case interval <= 350*time.Millisecond:
+	case interval < 350*time.Millisecond:
 		return time.Millisecond * 200 // 0.2s
 	// 0.75s
-	case interval <= 750*time.Millisecond:
+	case interval < 750*time.Millisecond:
 		return time.Millisecond * 500 // 0.5s
 	// 1.5s
-	case interval <= 1500*time.Millisecond:
+	case interval < 1500*time.Millisecond:
 		return time.Millisecond * 1000 // 1s
 	// 3.5s
-	case interval <= 3500*time.Millisecond:
+	case interval < 3500*time.Millisecond:
 		return time.Millisecond * 2000 // 2s
 	// 7.5s
-	case interval <= 7500*time.Millisecond:
+	case interval < 7500*time.Millisecond:
 		return time.Millisecond * 5000 // 5s
 	// 12.5s
-	case interval <= 12500*time.Millisecond:
+	case interval < 12500*time.Millisecond:
 		return time.Millisecond * 10000 // 10s
 	// 17.5s
-	case interval <= 17500*time.Millisecond:
+	case interval < 17500*time.Millisecond:
 		return time.Millisecond * 15000 // 15s
 	// 25s
-	case interval <= 25000*time.Millisecond:
+	case interval < 25000*time.Millisecond:
 		return time.Millisecond * 20000 // 20s
 	// 45s
-	case interval <= 45000*time.Millisecond:
+	case interval < 45000*time.Millisecond:
 		return time.Millisecond * 30000 // 30s
 	// 1.5m
-	case interval <= 90000*time.Millisecond:
+	case interval < 90000*time.Millisecond:
 		return time.Millisecond * 60000 // 1m
 	// 3.5m
-	case interval <= 210000*time.Millisecond:
+	case interval < 210000*time.Millisecond:
 		return time.Millisecond * 120000 // 2m
 	// 7.5m
-	case interval <= 450000*time.Millisecond:
+	case interval < 450000*time.Millisecond:
 		return time.Millisecond * 300000 // 5m
 	// 12.5m
-	case interval <= 750000*time.Millisecond:
+	case interval < 750000*time.Millisecond:
 		return time.Millisecond * 600000 // 10m
 	// 17.5m
-	case interval <= 1050000*time.Millisecond:
+	case interval < 1050000*time.Millisecond:
 		return time.Millisecond * 900000 // 15m
 	// 25m
-	case interval <= 1500000*time.Millisecond:
+	case interval < 1500000*time.Millisecond:
 		return time.Millisecond * 1200000 // 20m
 	// 45m
-	case interval <= 2700000*time.Millisecond:
+	case interval < 2700000*time.Millisecond:
 		return time.Millisecond * 1800000 // 30m
 	// 1.5h
-	case interval <= 5400000*time.Millisecond:
+	case interval < 5400000*time.Millisecond:
 		return time.Millisecond * 3600000 // 1h
 	// 2.5h
-	case interval <= 9000000*time.Millisecond:
+	case interval < 9000000*time.Millisecond:
 		return time.Millisecond * 7200000 // 2h
 	// 4.5h
-	case interval <= 16200000*time.Millisecond:
+	case interval < 16200000*time.Millisecond:
 		return time.Millisecond * 10800000 // 3h
 	// 9h
-	case interval <= 32400000*time.Millisecond:
+	case interval < 32400000*time.Millisecond:
 		return time.Millisecond * 21600000 // 6h
 	// 24h
-	case interval <= 86400000*time.Millisecond:
+	case interval < 86400000*time.Millisecond:
 		return time.Millisecond * 43200000 // 12h
 	// 48h
-	case interval <= 172800000*time.Millisecond:
+	case interval < 172800000*time.Millisecond:
 		return time.Millisecond * 86400000 // 24h
 	// 1w
-	case interval <= 604800000*time.Millisecond:
+	case interval < 604800000*time.Millisecond:
 		return time.Millisecond * 86400000 // 24h
 	// 3w
-	case interval <= 1814400000*time.Millisecond:
+	case interval < 1814400000*time.Millisecond:
 		return time.Millisecond * 604800000 // 1w
 	// 2y
 	case interval < 3628800000*time.Millisecond:


### PR DESCRIPTION
Related issue: #383 
Fixed unpredictable behavior when determining an interval for a range query  by updating interval comparison logic for `roundInterval` to use `<` instead of `<=` for consistency with grafana logic.
Fix is similar to [vl-datasource fix](https://github.com/VictoriaMetrics/victorialogs-datasource/pull/391)
