### PR TITLE
fix issue with intervals less than 1 second not being handled correctly in time parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## tip
 
 * BUGFIX: auto-calculate `step` param for a range queries consistently with other datasources. Before, `step` between datapoints on the graph could have use unexpected values depending on the time range. See [#383](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/383)
+* BUGFIX: fix issue with intervals less than 1 second not being handled correctly in time parsing. See [#376](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/376)
 
 ## v0.19.2
 

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -150,15 +150,15 @@ func TestDatasourceQueryRequest(t *testing.T) {
 
 	expected := []*data.Frame{
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "100"}, []float64{1}),
 		),
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "500"}, []float64{2}),
 		),
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "200"}, []float64{3}),
 		),
 	}
@@ -283,15 +283,15 @@ func TestDatasourceQueryRequest(t *testing.T) {
 
 	expected = []*data.Frame{
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}).SetConfig(&data.FieldConfig{Interval: 7777}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 7777}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "100"}, []float64{1}),
 		),
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}).SetConfig(&data.FieldConfig{Interval: 7777}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 7777}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "500"}, []float64{2}),
 		),
 		data.NewFrame("sum(ingress_nginx_request_qps)",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}).SetConfig(&data.FieldConfig{Interval: 7777}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}).SetConfig(&data.FieldConfig{Interval: 7777}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "200"}, []float64{3}),
 		),
 	}

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -103,7 +103,12 @@ func (pr promRange) dataframes() (data.Frames, error) {
 			if !ok {
 				return nil, fmt.Errorf("error get time from dataframes")
 			}
-			timestamps[j] = time.Unix(int64(v), 0)
+
+			var err error
+			timestamps[j], err = parseFloatToTime(v)
+			if err != nil {
+				return nil, fmt.Errorf("error get time from dataframes: %s", err)
+			}
 
 			f, err := strconv.ParseFloat(value[1].(string), 64)
 			if err != nil {

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -61,7 +61,16 @@ func (pi promInstant) dataframes() (data.Frames, error) {
 			return nil, fmt.Errorf("metric %v, unable to parse float64 from %s: %w", res, res.Value[1], err)
 		}
 
-		ts := time.Unix(int64(res.Value[0].(float64)), 0)
+		v, ok := res.Value[0].(float64)
+		if !ok {
+			return nil, fmt.Errorf("error get time from dataframes")
+		}
+
+		ts, err := parseFloatToTime(v)
+		if err != nil {
+			return nil, fmt.Errorf("error get time from dataframes: %s", err)
+		}
+
 		frames[i] = data.NewFrame("",
 			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{ts}),
 			data.NewField(data.TimeSeriesValueFieldName, data.Labels(res.Labels), []float64{f}))
@@ -138,9 +147,19 @@ func (ps promScalar) dataframes() (data.Frames, error) {
 		return nil, fmt.Errorf("metric %v, unable to parse float64 from %s: %w", ps, ps[1], err)
 	}
 
+	v, ok := ps[0].(float64)
+	if !ok {
+		return nil, fmt.Errorf("error get time from dataframes")
+	}
+
+	ts, err := parseFloatToTime(v)
+	if err != nil {
+		return nil, fmt.Errorf("error get time from dataframes: %s", err)
+	}
+
 	frames = append(frames,
 		data.NewFrame("",
-			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(int64(ps[0].(float64)), 0)}),
+			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{ts}),
 			data.NewField(data.TimeSeriesValueFieldName, nil, []float64{f})))
 
 	return frames, nil

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -99,13 +99,13 @@ func TestResponse_getDataFrames(t *testing.T) {
 		status: "success",
 		data: Data{
 			ResultType: "scalar",
-			Result:     []byte(`[1583786142, "1"]`),
+			Result:     []byte(`[1583786142.050, "1"]`),
 		},
 		query: Query{LegendFormat: "legend {{app}}"},
 		want: func() data.Frames {
 			return []*data.Frame{
 				data.NewFrame("",
-					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 0)}),
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 50*1e6)}),
 					data.NewField(data.TimeSeriesValueFieldName, nil, []float64{1}),
 				),
 			}
@@ -118,17 +118,17 @@ func TestResponse_getDataFrames(t *testing.T) {
 		status: "success",
 		data: Data{
 			ResultType: "vector",
-			Result:     []byte(`[{"metric":{"__name__":"vm_rows"},"value":[1583786142,"13763"]},{"metric":{"__name__":"vm_requests"},"value":[1583786140,"2000"]}]`),
+			Result:     []byte(`[{"metric":{"__name__":"vm_rows"},"value":[1583786142.05,"13763"]},{"metric":{"__name__":"vm_requests"},"value":[1583786140.05,"2000"]}]`),
 		},
 		query: Query{LegendFormat: "legend {{app}}"},
 		want: func() data.Frames {
 			return []*data.Frame{
 				data.NewFrame("legend ",
-					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 0)}),
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 50*1e6)}),
 					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "vm_rows"}, []float64{13763}),
 				),
 				data.NewFrame("legend ",
-					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786140, 0)}),
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786140, 50*1e6)}),
 					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "vm_requests"}, []float64{2000}),
 				),
 			}

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -147,15 +147,15 @@ func TestResponse_getDataFrames(t *testing.T) {
 		want: func() data.Frames {
 			return []*data.Frame{
 				data.NewFrame("legend ",
-					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}),
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}),
 					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "100"}, []float64{1}),
 				),
 				data.NewFrame("legend ",
-					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}),
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}),
 					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "500"}, []float64{2}),
 				),
 				data.NewFrame("legend ",
-					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 0)}),
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1670324477, 542*1e6)}),
 					data.NewField(data.TimeSeriesValueFieldName, data.Labels{"__name__": "ingress_nginx_request_qps", "status": "200"}, []float64{3}),
 				),
 			}

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -1,0 +1,24 @@
+package plugin
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// parseFloatToTime converts a floating-point timestamp to a time.Time instance with millisecond precision.
+func parseFloatToTime(timestamp float64) (time.Time, error) {
+	if timestamp < 0 {
+		return time.Now(), fmt.Errorf("error negative timestamp: %f", timestamp)
+	}
+	seconds := int64(timestamp)
+	// convert fractional part to string with 3 decimal places to avoid floating-point precision issues
+	frac := strconv.FormatFloat(timestamp, 'f', 3, 64)
+	frac = frac[len(frac)-3:]
+	ms, err := strconv.Atoi(frac)
+	if err != nil {
+		return time.Now(), fmt.Errorf("error convert fractional string to int: %s", err)
+	}
+	nanos := int64(ms) * 1e6
+	return time.Unix(seconds, nanos), nil
+}

--- a/pkg/plugin/utils_test.go
+++ b/pkg/plugin/utils_test.go
@@ -1,0 +1,108 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseFloatToTime(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     float64
+		wantTime  time.Time
+		expectErr bool
+	}{
+		{
+			name:      "whole second timestamp",
+			input:     1633046400.0,
+			wantTime:  time.Unix(1633046400, 0),
+			expectErr: false,
+		},
+		{
+			name:      "timestamp with milliseconds",
+			input:     1633046400.123,
+			wantTime:  time.Unix(1633046400, 123*1e6),
+			expectErr: false,
+		},
+		{
+			name:      "timestamp with rounding",
+			input:     1633046400.56789,
+			wantTime:  time.Unix(1633046400, 568*1e6),
+			expectErr: false,
+		},
+		{
+			name:      "negative timestamp",
+			input:     -1633046400.456,
+			wantTime:  time.Now(),
+			expectErr: true,
+		},
+		{
+			name:      "invalid fractional part string",
+			input:     1633046400.999999999,         // Beyond 3 decimal places
+			wantTime:  time.Unix(1633046400, 1*1e9), // Expect a recent time as fallback
+			expectErr: false,
+		},
+		{
+			name:      "zero timestamp",
+			input:     0.0,
+			wantTime:  time.Unix(0, 0),
+			expectErr: false,
+		},
+		{
+			name:      "fractional timestamp without rounding",
+			input:     1633046400.500,
+			wantTime:  time.Unix(1633046400, 500*1e6),
+			expectErr: false,
+		},
+		{
+			name:      "fractional timestamp 50ms",
+			input:     1633046400.05,
+			wantTime:  time.Unix(1633046400, 50*1e6),
+			expectErr: false,
+		},
+		{
+			name:      "fractional timestamp 5ms",
+			input:     1633046400.005,
+			wantTime:  time.Unix(1633046400, 5*1e6),
+			expectErr: false,
+		},
+		{
+			name:      "maximum fractional digits (valid)",
+			input:     1633046400.999,
+			wantTime:  time.Unix(1633046400, 999*1e6),
+			expectErr: false,
+		},
+		{
+			name:      "near Unix time lower boundary",
+			input:     -1.123,
+			wantTime:  time.Now(), // Expect error for negative timestamp
+			expectErr: true,
+		},
+		{
+			name:      "fractional part with trailing zeros",
+			input:     1633046400.120,
+			wantTime:  time.Unix(1633046400, 120*1e6),
+			expectErr: false,
+		},
+		{
+			name:      "timestamp with zero milliseconds",
+			input:     1633046400.000,
+			wantTime:  time.Unix(1633046400, 0),
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTime, err := parseFloatToTime(tt.input)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("expected error: %v, got: %v", tt.expectErr, err != nil)
+			}
+
+			if !tt.expectErr && !gotTime.Equal(tt.wantTime) {
+				t.Errorf("expected time: %v, got: %v", tt.wantTime, gotTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related issue: #376 
Fixed issue with intervals less than 1 second not being handled correctly in time parsing by converting fractional part to string with milliseconds precision.
<img width="1342" height="827" alt="image" src="https://github.com/user-attachments/assets/e6e35eb3-529c-4c3c-b6a6-44657e0f2cce" />
<img width="1344" height="842" alt="image" src="https://github.com/user-attachments/assets/587cb492-9894-4ae2-93d8-52ec3cd8ed2c" />

