### PR TITLE
docs: use src/README.md as source for docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - .github/workflows/docs.yaml
-      - README.md
+      - src/README.md
       - docs/**
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
           export TARGET="../__vm-docs/content/victoriametrics-grafana-datasource"
           rm -rf ${TARGET}
           cp -r docs ${TARGET}
-          cp README.md ${TARGET}/
+          cp src/README.md ${TARGET}/
           sed -i '/VictoriaMetrics datasource for Grafana/g' ${TARGET}/README.md
           sed -i 's|docs/assets/|grafana-datasource/assets/|g' ${TARGET}/README.md
           echo "SHORT_SHA=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_OUTPUT

--- a/src/README.md
+++ b/src/README.md
@@ -1,10 +1,10 @@
 # VictoriaMetrics datasource for Grafana
 
-The VictoriaMetrics Grafana plugin allows Grafana to query, visualize,
-and interact with [VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/),
+The [VictoriaMetrics Grafana plugin](https://grafana.com/grafana/plugins/victoriametrics-metrics-datasource/) allows 
+Grafana to query, visualize, and interact with [VictoriaMetrics](https://docs.victoriametrics.com/victoriametrics/),
 a high-performance metrics storage and processing system.
 
-<img alt="Grafana Dashboard Screenshot" src="https://raw.githubusercontent.com/VictoriaMetrics/victoriametrics-datasource/b8bf7398a9a14ba917094385d8fee08cb7e303a1/src/img/dashboard.png">
+<img alt="Grafana Dashboard Screenshot" width="100%" src="https://raw.githubusercontent.com/VictoriaMetrics/victoriametrics-datasource/b8bf7398a9a14ba917094385d8fee08cb7e303a1/src/img/dashboard.png">
 
 ## Capabilities
 
@@ -21,6 +21,7 @@ Try it at [VictoriaMetrics playground](https://play-grafana.victoriametrics.com/
 ## Installation
 
 For detailed instructions on how to install the plugin on Grafana Cloud or locally, please checkout the [Plugin installation docs](https://grafana.com/docs/grafana/latest/plugins/installation/).
+For installation options in Docker or Kubernetes refer to [these docs](https://github.com/VictoriaMetrics/victoriametrics-datasource?tab=readme-ov-file#installation).
 
 ### Manual configuration via UI
 


### PR DESCRIPTION
This change uses the public-facing src/readme.md as source for https://docs.victoriametrics.com/victoriametrics/victoriametrics-datasource/.

The `src/README.md` is readme displayed in Grafana's plugins catalogue. It is more user friendly and focused on using the plugin. While the current root's README.md has a lot of extra info about development and advanced installation methods that might be not relevant to majority of users.