### PR TITLE
fix the problem with health check URL generation where the `/select/`…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: fix the problem with health check URL generation where the `/select/` prefix was incorrectly included in the health endpoint path. Health check is working properly now. See [#388](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/388).
+
 ## v0.19.3
 
 * BUGFIX: auto-calculate `step` param for a range queries consistently with other datasources. Before, `step` between datapoints on the graph could have use unexpected values depending on the time range. See [#383](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/383)

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -317,7 +317,7 @@ func newURL(urlStr, p string, root bool) (*url.URL, error) {
 		return nil, fmt.Errorf("failed to parse datasource url: %s", err)
 	}
 	if root {
-		if idx := strings.Index(u.Path, "/select/"); idx > 0 {
+		if idx := strings.Index(u.Path, "/select/"); idx != -1 {
 			u.Path = u.Path[:idx]
 		}
 	}

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -592,6 +592,22 @@ func TestNewURL(t *testing.T) {
 			expected:  "http://example.com/base/somepath/api/v1/resource",
 			expectErr: false,
 		},
+		{
+			name:      "valid root slicing for single url",
+			urlStr:    "http://localhost:8428/",
+			path:      "/-/healthy",
+			root:      true,
+			expected:  "http://localhost:8428/-/healthy",
+			expectErr: false,
+		},
+		{
+			name:      "valid root slicing for cluster url with auth",
+			urlStr:    "http://localhost:8427/select/0/prometheus",
+			path:      "/-/healthy",
+			root:      true,
+			expected:  "http://localhost:8427/-/healthy",
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Related issue: #388 
Fixed the problem with health check URL generation where the `/select/` prefix was incorrectly included in the health endpoint path. The health endpoint now correctly strips the `/select/` prefix from the base URL before appending the health check path, ensuring proper health check functionality