### PR TITLE
fix: bring back warning about partial response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## tip
 
-* BUGFIX: bring back warning about partial response. See [#542](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/542).
+* BUGFIX: bring back warning about partial response. See [#542](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/542). Thanks to @ilyalabun for contributing.
 
 ## v0.25.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* BUGFIX: bring back warning about partial response. See [#542](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/542).
+
 ## v0.25.2
 
 * BUGFIX: fix client-side crash when opening the variable editor with the `Label values` query type on Grafana 13.x. See [#532](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/532).

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -63,7 +63,7 @@ func TestDatasourceQueryRequest(t *testing.T) {
 				t.Fatalf("error write response: %s", err)
 			}
 		case 6:
-			_, err := w.Write([]byte(`{"status":"success","data":{"resultType":"scalar","result":[1583786142, "1"]}}`))
+			_, err := w.Write([]byte(`{"status":"success","isPartial":true,"data":{"resultType":"scalar","result":[1583786142, "1"]}}`))
 			if err != nil {
 				t.Fatalf("error write response: %s", err)
 			}
@@ -234,7 +234,13 @@ func TestDatasourceQueryRequest(t *testing.T) {
 		data.NewFrame("",
 			data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 0)}),
 			data.NewField(data.TimeSeriesValueFieldName, nil, []float64{1}),
-		).SetMeta(&data.FrameMeta{Custom: &CustomMeta{ResultType: scalar}}),
+		).SetMeta(&data.FrameMeta{
+			Custom: &CustomMeta{ResultType: scalar},
+			Notices: []data.Notice{{
+				Severity: data.NoticeSeverityWarning,
+				Text:     partialResponseWarning,
+			}},
+		}),
 	}
 
 	response = rsp.Responses["A"]

--- a/pkg/plugin/response.go
+++ b/pkg/plugin/response.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	vector, matrix, scalar = "vector", "matrix", "scalar"
+	partialResponseWarning = "The shown results are marked as PARTIAL. The result is marked as partial if one or more vmstorage nodes failed to respond to the query."
 )
 
 type CustomMeta struct {
@@ -47,6 +48,7 @@ type Response struct {
 	Error       string `json:"error,omitempty"`
 	Data        Data   `json:"data"`
 	Trace       *Trace `json:"trace,omitempty"`
+	IsPartial   bool   `json:"isPartial,omitempty"`
 	ForAlerting bool   `json:"-"`
 }
 
@@ -212,7 +214,11 @@ func (r *Response) getDataFrames() (fss data.Frames, err error) {
 			return nil, fmt.Errorf("unmarshal err %w; \n %#v", err, string(r.Data.Result))
 		}
 		if r.ForAlerting {
-			return pi.alertingDataFrames()
+			fss, err = pi.alertingDataFrames()
+			if err != nil {
+				return nil, err
+			}
+			return r.addNotices(fss), nil
 		}
 		df = pi
 	case matrix:
@@ -233,6 +239,25 @@ func (r *Response) getDataFrames() (fss data.Frames, err error) {
 	if frames, err := df.dataframes(); err != nil {
 		return nil, err
 	} else {
-		return append(fss, frames...), nil
+		return append(fss, r.addNotices(frames)...), nil
 	}
+}
+
+func (r *Response) addNotices(frames data.Frames) data.Frames {
+	if !r.IsPartial {
+		return frames
+	}
+
+	notice := data.Notice{
+		Severity: data.NoticeSeverityWarning,
+		Text:     partialResponseWarning,
+	}
+	for _, frame := range frames {
+		if frame.Meta == nil {
+			frame.Meta = &data.FrameMeta{}
+		}
+		frame.Meta.Notices = append(frame.Meta.Notices, notice)
+	}
+
+	return frames
 }

--- a/pkg/plugin/response_test.go
+++ b/pkg/plugin/response_test.go
@@ -17,6 +17,7 @@ func TestResponse_getDataFrames(t *testing.T) {
 		want        func() data.Frames
 		wantErr     bool
 		trace       *Trace
+		isPartial   bool
 	}
 	f := func(opts opts) {
 		t.Helper()
@@ -25,6 +26,7 @@ func TestResponse_getDataFrames(t *testing.T) {
 			Data:        opts.data,
 			ForAlerting: opts.forAlerting,
 			Trace:       opts.trace,
+			IsPartial:   opts.isPartial,
 		}
 		got, err := r.getDataFrames()
 		if (err != nil) != opts.wantErr {
@@ -67,9 +69,10 @@ func TestResponse_getDataFrames(t *testing.T) {
 	}
 	f(o)
 
-	// scalar result type with trace
+	// partial scalar result type with trace
 	o = opts{
-		status: "success",
+		status:    "success",
+		isPartial: true,
 		data: Data{
 			ResultType: "scalar",
 			Result:     []byte(`[1583786142, "1"]`),
@@ -89,7 +92,13 @@ func TestResponse_getDataFrames(t *testing.T) {
 				data.NewFrame("",
 					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 0)}),
 					data.NewField(data.TimeSeriesValueFieldName, nil, []float64{1}),
-				).SetMeta(&data.FrameMeta{Custom: &CustomMeta{ResultType: scalar}}),
+				).SetMeta(&data.FrameMeta{
+					Custom: &CustomMeta{ResultType: scalar},
+					Notices: []data.Notice{{
+						Severity: data.NoticeSeverityWarning,
+						Text:     partialResponseWarning,
+					}},
+				}),
 			}
 		},
 		wantErr: false,
@@ -139,6 +148,32 @@ func TestResponse_getDataFrames(t *testing.T) {
 					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 50*1e6)}),
 					data.NewField(data.TimeSeriesValueFieldName, nil, []float64{1}),
 				).SetMeta(&data.FrameMeta{Custom: &CustomMeta{ResultType: scalar}}),
+			}
+		},
+	}
+	f(o)
+
+	// partial scalar response
+	o = opts{
+		status:    "success",
+		isPartial: true,
+		data: Data{
+			ResultType: "scalar",
+			Result:     []byte(`[1583786142.050, "1"]`),
+		},
+		query: Query{},
+		want: func() data.Frames {
+			return []*data.Frame{
+				data.NewFrame("",
+					data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{time.Unix(1583786142, 50*1e6)}),
+					data.NewField(data.TimeSeriesValueFieldName, nil, []float64{1}),
+				).SetMeta(&data.FrameMeta{
+					Custom: &CustomMeta{ResultType: scalar},
+					Notices: []data.Notice{{
+						Severity: data.NoticeSeverityWarning,
+						Text:     partialResponseWarning,
+					}},
+				}),
 			}
 		},
 	}


### PR DESCRIPTION
### Describe Your Changes

In version `v0.7.0`, commit 75899ee1 added frontend handling for `isPartial` response field. The old `transform()` function checked `response.data.isPartial` and added a Grafana frame notice:

```
{
  severity: 'warning',
  text: 'The shown results are marked as PARTIAL...'
}
```

Later, commit 115d740b migrated query execution from the browser-side implementation to the Go backend. After that change:

- Queries were sent through `DataSourceWithBackend`.
- The old frontend `transform()` function was no longer called.
- The Go backend became responsible for decoding VictoriaMetrics responses and creating Grafana data frames.
- The `isPartial` handling was not ported to the Go backend.

This commit adds partial response handling to the plugin's backend.

Related issue: #542

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
