### PR TITLE
539 align start/end by step in all query range requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FEATURE: align `start` and `end` of range queries to the query step. See [#539](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/539).
 
 * BUGFIX: bring back warning about partial response. See [#542](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/542). Thanks to @ilyalabun for contributing.
+* BUGFIX: send `start`, `end` and `time` query params as unix milliseconds instead of whole seconds, so zoomed-in graphs with sub-second steps are no longer cut off at the edges. See [#539](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/539).
 
 ## v0.25.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* FEATURE: align `start` and `end` of range queries to the query step. See [#539](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/539).
+
 * BUGFIX: bring back warning about partial response. See [#542](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/542). Thanks to @ilyalabun for contributing.
 
 ## v0.25.2

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -73,8 +73,8 @@ func (q *Query) getQueryURL(rawURL string, queryParams url.Values) (string, erro
 			}
 		}
 		aligned := q.TimeRange.alignToStep(step, q.UTCOffsetSec)
-		values.Add("start", strconv.FormatInt(aligned.From.Unix(), 10))
-		values.Add("end", strconv.FormatInt(aligned.To.Unix(), 10))
+		values.Add("start", formatTimestamp(aligned.From))
+		values.Add("end", formatTimestamp(aligned.To))
 	} else {
 		u, err = newURL(rawURL, instantQueryPath, false)
 		if err != nil {
@@ -86,7 +86,7 @@ func (q *Query) getQueryURL(rawURL string, queryParams url.Values) (string, erro
 				values.Add(k, v)
 			}
 		}
-		values.Set("time", strconv.FormatInt(q.TimeRange.To.Unix(), 10))
+		values.Set("time", formatTimestamp(q.TimeRange.To))
 	}
 	if q.Trace > 0 {
 		values.Set("trace", strconv.Itoa(q.Trace))

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"fmt"
-	"math"
 	"net/url"
 	"regexp"
 	"sort"
@@ -33,15 +32,10 @@ type Query struct {
 	Expr                 string `json:"expr"`
 	LegendFormat         string `json:"legendFormat"`
 	Trace                int    `json:"trace,omitempty"`
+	UTCOffsetSec         int64  `json:"utcOffsetSec"` // dashboard time zone offset from UTC, used to align range query start/end to step
 	MaxDataPoints        int64
 	TimeRange            TimeRange
 	BackendQueryInterval time.Duration
-}
-
-// TimeRange represents time range backend object
-type TimeRange struct {
-	From time.Time
-	To   time.Time
 }
 
 // getQueryURL calculates step and clear expression from template variables,
@@ -78,9 +72,9 @@ func (q *Query) getQueryURL(rawURL string, queryParams url.Values) (string, erro
 				values.Add(k, v)
 			}
 		}
-		values.Add("start", strconv.FormatInt(q.TimeRange.From.Unix(), 10))
-		entTime := int64(math.Ceil(float64(q.TimeRange.To.UnixMilli()) / 1000))
-		values.Add("end", strconv.FormatInt(entTime, 10))
+		aligned := q.TimeRange.alignToStep(step, q.UTCOffsetSec)
+		values.Add("start", strconv.FormatInt(aligned.From.Unix(), 10))
+		values.Add("end", strconv.FormatInt(aligned.To.Unix(), 10))
 	} else {
 		u, err = newURL(rawURL, instantQueryPath, false)
 		if err != nil {

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -97,7 +97,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query?query=rate%28ingress_nginx_request_qps%7B%7D%5B10s%5D%29&step=10s&time=1670226793",
+		want:         "http://127.0.0.1:8428/api/v1/query?query=rate%28ingress_nginx_request_qps%7B%7D%5B10s%5D%29&step=10s&time=1670226793000",
 	}
 	f(o)
 
@@ -114,7 +114,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange:  getTimeRage,
 		rawURL:        "http://127.0.0.1:8428",
 		wantErr:       false,
-		want:          "http://127.0.0.1:8428/api/v1/query?query=rate%28ingress_nginx_request_qps%7B%7D%5B1m20s%5D%29&step=20s&time=1670226793",
+		want:          "http://127.0.0.1:8428/api/v1/query?query=rate%28ingress_nginx_request_qps%7B%7D%5B1m20s%5D%29&step=20s&time=1670226793000",
 	}
 	f(o)
 
@@ -131,7 +131,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange:  getTimeRage,
 		rawURL:        "http://127.0.0.1:8428",
 		wantErr:       false,
-		want:          "http://127.0.0.1:8428/api/v1/query_range?end=1670226790&query=rate%28ingress_nginx_request_qps%7B%7D%5B20s%5D%29&start=1670226730&step=5s",
+		want:          "http://127.0.0.1:8428/api/v1/query_range?end=1670226790000&query=rate%28ingress_nginx_request_qps%7B%7D%5B20s%5D%29&start=1670226730000&step=5s",
 	}
 	f(o)
 
@@ -146,7 +146,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226750&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226600&step=2m30s",
+		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226750000&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226600000&step=2m30s",
 	}
 	f(o)
 
@@ -161,7 +161,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226750&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226600&step=2m30s",
+		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226750000&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226600000&step=2m30s",
 	}
 	f(o)
 
@@ -176,7 +176,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226720&query=rate%28rpc_durations_seconds_count%5B8m0s%5D%29&start=1670226720&step=2m0s",
+		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226720000&query=rate%28rpc_durations_seconds_count%5B8m0s%5D%29&start=1670226720000&step=2m0s",
 	}
 	f(o)
 
@@ -195,7 +195,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230320&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720&step=30s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230320000&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720000&step=30s",
 	}
 	f(o)
 
@@ -214,7 +214,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670226720&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720&step=30s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670226720000&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720000&step=30s",
 	}
 	f(o)
 
@@ -233,7 +233,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230320&query=rate%28rpc_durations_seconds_count%5B30s%5D%29&start=1670226720&step=30s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230320000&query=rate%28rpc_durations_seconds_count%5B30s%5D%29&start=1670226720000&step=30s",
 	}
 	f(o)
 
@@ -252,7 +252,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670399520&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720&step=2m0s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670399520000&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720000&step=2m0s",
 	}
 	f(o)
 	// range query with 1d step is aligned to local midnight using utcOffsetSec (UTC+4)
@@ -271,7 +271,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670356800&query=up&start=1670184000&step=24h0m0s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670356800000&query=up&start=1670184000000&step=24h0m0s",
 	}
 	f(o)
 
@@ -286,7 +286,41 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query?query=up&step=1h0m0s&time=1670226793",
+		want:         "http://127.0.0.1:8428/api/v1/query?query=up&step=1h0m0s&time=1670226793000",
+	}
+	f(o)
+	// millisecond time range with sub-second step keeps millisecond precision in start/end
+	o = opts{
+		RefID:      "1",
+		Instant:    false,
+		Range:      true,
+		Expr:       "up",
+		Interval:   "200ms",
+		IntervalMs: 200,
+		getTimeRange: func() TimeRange {
+			from := time.Unix(1670226733, 631_000_000)
+			to := time.Unix(1670226734, 631_000_000)
+			return TimeRange{From: from, To: to}
+		},
+		rawURL:  "http://127.0.0.1:8428",
+		wantErr: false,
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670226734600&query=up&start=1670226733600&step=200ms",
+	}
+	f(o)
+
+	// instant query keeps millisecond precision in time
+	o = opts{
+		RefID:    "1",
+		Instant:  true,
+		Range:    false,
+		Expr:     "up",
+		Interval: "1h",
+		getTimeRange: func() TimeRange {
+			return TimeRange{From: time.Unix(1670226733, 0), To: time.Unix(1670226793, 250_000_000)}
+		},
+		rawURL:  "http://127.0.0.1:8428",
+		wantErr: false,
+		want:    "http://127.0.0.1:8428/api/v1/query?query=up&step=1h0m0s&time=1670226793250",
 	}
 	f(o)
 }

--- a/pkg/plugin/query_test.go
+++ b/pkg/plugin/query_test.go
@@ -18,6 +18,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		TimeInterval  string
 		Expr          string
 		MaxDataPoints int64
+		UTCOffsetSec  int64
 		getTimeRange  func() TimeRange
 		rawURL        string
 		params        string
@@ -35,6 +36,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 			TimeInterval:  opts.TimeInterval,
 			Expr:          opts.Expr,
 			MaxDataPoints: opts.MaxDataPoints,
+			UTCOffsetSec:  opts.UTCOffsetSec,
 			TimeRange:     opts.getTimeRange(),
 		}
 		params, err := url.ParseQuery(opts.params)
@@ -129,7 +131,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange:  getTimeRage,
 		rawURL:        "http://127.0.0.1:8428",
 		wantErr:       false,
-		want:          "http://127.0.0.1:8428/api/v1/query_range?end=1670226793&query=rate%28ingress_nginx_request_qps%7B%7D%5B20s%5D%29&start=1670226733&step=5s",
+		want:          "http://127.0.0.1:8428/api/v1/query_range?end=1670226790&query=rate%28ingress_nginx_request_qps%7B%7D%5B20s%5D%29&start=1670226730&step=5s",
 	}
 	f(o)
 
@@ -144,7 +146,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226793&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226733&step=2m30s",
+		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226750&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226600&step=2m30s",
 	}
 	f(o)
 
@@ -159,7 +161,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226793&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226733&step=2m30s",
+		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226750&query=rate%28rpc_durations_seconds_count%5B10m0s%5D%29&start=1670226600&step=2m30s",
 	}
 	f(o)
 
@@ -174,7 +176,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		getTimeRange: getTimeRage,
 		rawURL:       "http://127.0.0.1:8428",
 		wantErr:      false,
-		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226793&query=rate%28rpc_durations_seconds_count%5B8m0s%5D%29&start=1670226733&step=2m0s",
+		want:         "http://127.0.0.1:8428/api/v1/query_range?end=1670226720&query=rate%28rpc_durations_seconds_count%5B8m0s%5D%29&start=1670226720&step=2m0s",
 	}
 	f(o)
 
@@ -193,11 +195,11 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230333&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226733&step=30s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230320&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720&step=30s",
 	}
 	f(o)
 
-	// end interval rounded to ceil
+	// time range shorter than step collapses to a single step-aligned point
 	o = opts{
 		RefID:      "1",
 		Instant:    false,
@@ -212,7 +214,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670226734&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226733&step=30s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670226720&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720&step=30s",
 	}
 	f(o)
 
@@ -231,7 +233,7 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230333&query=rate%28rpc_durations_seconds_count%5B30s%5D%29&start=1670226733&step=30s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670230320&query=rate%28rpc_durations_seconds_count%5B30s%5D%29&start=1670226720&step=30s",
 	}
 	f(o)
 
@@ -250,7 +252,41 @@ func TestQuery_getQueryURL(t *testing.T) {
 		},
 		rawURL:  "http://127.0.0.1:8428",
 		wantErr: false,
-		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670399533&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226733&step=2m0s",
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670399520&query=rate%28rpc_durations_seconds_count%5B2m0s%5D%29&start=1670226720&step=2m0s",
+	}
+	f(o)
+	// range query with 1d step is aligned to local midnight using utcOffsetSec (UTC+4)
+	o = opts{
+		RefID:        "1",
+		Instant:      false,
+		Range:        true,
+		Expr:         "up",
+		Interval:     "1d",
+		IntervalMs:   86400000,
+		UTCOffsetSec: 14400,
+		getTimeRange: func() TimeRange {
+			from := time.Unix(1670226733, 0)
+			to := from.Add(time.Hour * 24 * 2)
+			return TimeRange{From: from, To: to}
+		},
+		rawURL:  "http://127.0.0.1:8428",
+		wantErr: false,
+		want:    "http://127.0.0.1:8428/api/v1/query_range?end=1670356800&query=up&start=1670184000&step=24h0m0s",
+	}
+	f(o)
+
+	// instant query is not aligned to step
+	o = opts{
+		RefID:        "1",
+		Instant:      true,
+		Range:        false,
+		Expr:         "up",
+		Interval:     "1h",
+		UTCOffsetSec: 14400,
+		getTimeRange: getTimeRage,
+		rawURL:       "http://127.0.0.1:8428",
+		wantErr:      false,
+		want:         "http://127.0.0.1:8428/api/v1/query?query=up&step=1h0m0s&time=1670226793",
 	}
 	f(o)
 }

--- a/pkg/plugin/timerange.go
+++ b/pkg/plugin/timerange.go
@@ -1,0 +1,38 @@
+package plugin
+
+import "time"
+
+type TimeRange struct {
+	From time.Time
+	To   time.Time
+}
+
+// alignToStep rounds both ends of the range down to a multiple of step,
+// the same way Grafana Prometheus datasource does for query_range requests.
+// It keeps start/end stable between about-same-time queries
+func (tr TimeRange) alignToStep(step time.Duration, utcOffsetSec int64) TimeRange {
+	if step <= 0 {
+		return tr
+	}
+	offset := time.Duration(utcOffsetSec) * time.Second
+	return TimeRange{
+		From: alignTime(tr.From, step, offset),
+		To:   alignTime(tr.To, step, offset),
+	}
+}
+
+// alignTime rounds t down to a multiple of step relative to the Unix epoch shifted by offset.
+func alignTime(t time.Time, step, offset time.Duration) time.Time {
+	shifted := t.UnixNano() + int64(offset)
+	aligned := floorDiv(shifted, int64(step))*int64(step) - int64(offset)
+	return time.Unix(0, aligned).UTC()
+}
+
+// floorDiv returns a/b rounded towards negative infinity.
+func floorDiv(a, b int64) int64 {
+	q := a / b
+	if a%b != 0 && (a < 0) != (b < 0) {
+		q--
+	}
+	return q
+}

--- a/pkg/plugin/timerange.go
+++ b/pkg/plugin/timerange.go
@@ -1,6 +1,9 @@
 package plugin
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
 
 type TimeRange struct {
 	From time.Time
@@ -35,4 +38,9 @@ func floorDiv(a, b int64) int64 {
 		q--
 	}
 	return q
+}
+
+// formatTimestamp formats t as unix milliseconds for the start/end/time query params.
+func formatTimestamp(t time.Time) string {
+	return strconv.FormatInt(t.UnixMilli(), 10)
 }

--- a/pkg/plugin/timerange.go
+++ b/pkg/plugin/timerange.go
@@ -14,30 +14,25 @@ type TimeRange struct {
 // the same way Grafana Prometheus datasource does for query_range requests.
 // It keeps start/end stable between about-same-time queries
 func (tr TimeRange) alignToStep(step time.Duration, utcOffsetSec int64) TimeRange {
-	if step <= 0 {
+	stepMs := step.Milliseconds()
+	if stepMs <= 0 {
 		return tr
 	}
-	offset := time.Duration(utcOffsetSec) * time.Second
+	offsetMs := utcOffsetSec * 1000
 	return TimeRange{
-		From: alignTime(tr.From, step, offset),
-		To:   alignTime(tr.To, step, offset),
+		From: alignTime(tr.From, stepMs, offsetMs),
+		To:   alignTime(tr.To, stepMs, offsetMs),
 	}
 }
 
 // alignTime rounds t down to a multiple of step relative to the Unix epoch shifted by offset.
-func alignTime(t time.Time, step, offset time.Duration) time.Time {
-	shifted := t.UnixNano() + int64(offset)
-	aligned := floorDiv(shifted, int64(step))*int64(step) - int64(offset)
-	return time.Unix(0, aligned).UTC()
-}
-
-// floorDiv returns a/b rounded towards negative infinity.
-func floorDiv(a, b int64) int64 {
-	q := a / b
-	if a%b != 0 && (a < 0) != (b < 0) {
+func alignTime(t time.Time, stepMs, offsetMs int64) time.Time {
+	shifted := t.UnixMilli() + offsetMs
+	q := shifted / stepMs
+	if shifted%stepMs < 0 {
 		q--
 	}
-	return q
+	return time.UnixMilli(q*stepMs - offsetMs).UTC()
 }
 
 // formatTimestamp formats t as unix milliseconds for the start/end/time query params.

--- a/pkg/plugin/timerange_test.go
+++ b/pkg/plugin/timerange_test.go
@@ -47,3 +47,19 @@ func TestTimeRange_alignToStep(t *testing.T) {
 	f(tr, 0, 0, 1670226733, 1670226793)
 	f(tr, -time.Second, 0, 1670226733, 1670226793)
 }
+
+func Test_formatTimestamp(t *testing.T) {
+	f := func(ts time.Time, want string) {
+		t.Helper()
+		if got := formatTimestamp(ts); got != want {
+			t.Errorf("formatTimestamp(%v) = %q, want %q", ts, got, want)
+		}
+	}
+
+	f(time.Unix(1670226733, 0), "1670226733000")
+	f(time.Unix(1670226733, 631_000_000), "1670226733631")
+	f(time.Unix(1670226733, 5_000_000), "1670226733005")
+	// sub-millisecond part is dropped
+	f(time.Unix(1670226733, 631_456_789), "1670226733631")
+	f(time.Unix(0, 0), "0")
+}

--- a/pkg/plugin/timerange_test.go
+++ b/pkg/plugin/timerange_test.go
@@ -1,0 +1,49 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeRange_alignToStep(t *testing.T) {
+	f := func(tr TimeRange, step time.Duration, utcOffsetSec int64, wantFrom, wantTo int64) {
+		t.Helper()
+		got := tr.alignToStep(step, utcOffsetSec)
+		if got.From.Unix() != wantFrom {
+			t.Errorf("alignToStep() From = %d, want %d", got.From.Unix(), wantFrom)
+		}
+		if got.To.Unix() != wantTo {
+			t.Errorf("alignToStep() To = %d, want %d", got.To.Unix(), wantTo)
+		}
+	}
+
+	// 2022-12-05 08:32:13 UTC .. 08:33:13 UTC
+	tr := TimeRange{From: time.Unix(1670226733, 0), To: time.Unix(1670226793, 0)}
+
+	// both ends are rounded down to a multiple of step
+	f(tr, 5*time.Second, 0, 1670226730, 1670226790)
+	f(tr, 30*time.Second, 0, 1670226720, 1670226780)
+
+	// range shorter than step collapses to a single aligned point
+	f(tr, time.Hour, 0, 1670223600, 1670223600)
+
+	// already aligned range is left untouched
+	aligned := TimeRange{From: time.Unix(1670223600, 0), To: time.Unix(1670227200, 0)}
+	f(aligned, time.Hour, 0, 1670223600, 1670227200)
+
+	// sub-second part of the range boundary is dropped by the alignment
+	withMillis := TimeRange{From: time.Unix(1670226733, 0), To: time.Unix(1670226733, 100_000_000)}
+	f(withMillis, 30*time.Second, 0, 1670226720, 1670226720)
+
+	// utc offset shifts the alignment grid so that 1d step lands on local midnight
+	f(tr, 24*time.Hour, 0, 1670198400, 1670198400)      // 2022-12-05 00:00 UTC
+	f(tr, 24*time.Hour, 14400, 1670184000, 1670184000)  // 2022-12-05 00:00 UTC+4
+	f(tr, 24*time.Hour, -18000, 1670216400, 1670216400) // 2022-12-05 00:00 UTC-5
+
+	// utc offset does not change alignment when it is a multiple of step
+	f(tr, time.Hour, 14400, 1670223600, 1670223600)
+
+	// non-positive step disables alignment
+	f(tr, 0, 0, 1670226733, 1670226793)
+	f(tr, -time.Second, 0, 1670226733, 1670226793)
+}

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1037,12 +1037,29 @@ describe('processTargetV2', () => {
     );
   });
 
+  it('should take utcOffsetSec from the request range (dashboard time zone), not from timeSrv', () => {
+    const target = { expr: 'metric_name', refId: 'A', range: true, instant: false } as any;
+    const request = {
+      dashboardUID: 'dashboard_1',
+      targets: [],
+      panelId: 2,
+      app: 'app_1',
+      // dashboard time zone is UTC+2 while the timeSrv stub reports the browser offset 0
+      range: { to: { utcOffset: () => 120 } },
+    } as unknown as DataQueryRequest<PromQuery>;
+
+    const result = datasource.processTargetV2(target, request);
+
+    expect((result as any).utcOffsetSec).toBe(7200);
+  });
+
   it('should merge template with query and adjust target properties', () => {
     const target = { expr: 'sr', refId: 'A', range: false, instant: false, } as any;
     const request = {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
+      range: { to: { utcOffset: () => 0 } },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1067,6 +1084,7 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
+      range: { to: { utcOffset: () => 0 } },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1100,6 +1118,7 @@ describe('processTargetV2', () => {
       dashboardUID: 'unknown_dashboard',
       targets: [],
       panelId: 2,
+      range: { to: { utcOffset: () => 0 } },
       app: 'unknown_app',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1122,6 +1141,7 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
+      range: { to: { utcOffset: () => 0 } },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1154,6 +1174,7 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
+      range: { to: { utcOffset: () => 0 } },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1186,6 +1207,7 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
+      range: { to: { utcOffset: () => 0 } },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1220,6 +1242,7 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
+      range: { to: { utcOffset: () => 0 } },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1037,20 +1037,38 @@ describe('processTargetV2', () => {
     );
   });
 
-  it('should take utcOffsetSec from the request range (dashboard time zone), not from timeSrv', () => {
+  it('should take utcOffsetSec from the request time zone even for an absolute range in the browser time zone', () => {
     const target = { expr: 'metric_name', refId: 'A', range: true, instant: false } as any;
     const request = {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
       app: 'app_1',
-      // dashboard time zone is UTC+2 while the timeSrv stub reports the browser offset 0
-      range: { to: { utcOffset: () => 120 } },
+      timezone: 'Europe/Berlin',
+      // absolute ranges are parsed by Grafana with plain dateTime(), i.e. in the browser time zone (UTC in tests)
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
     } as unknown as DataQueryRequest<PromQuery>;
 
     const result = datasource.processTargetV2(target, request);
 
+    // Europe/Berlin is UTC+2 (CEST) at that instant; the timeSrv stub still reports 0
     expect((result as any).utcOffsetSec).toBe(7200);
+  });
+
+  it('should use zero utcOffsetSec for a UTC request time zone', () => {
+    const target = { expr: 'metric_name', refId: 'A', range: true, instant: false } as any;
+    const request = {
+      dashboardUID: 'dashboard_1',
+      targets: [],
+      panelId: 2,
+      app: 'app_1',
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
+    } as unknown as DataQueryRequest<PromQuery>;
+
+    const result = datasource.processTargetV2(target, request);
+
+    expect((result as any).utcOffsetSec).toBe(0);
   });
 
   it('should merge template with query and adjust target properties', () => {
@@ -1059,7 +1077,8 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
-      range: { to: { utcOffset: () => 0 } },
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1084,7 +1103,8 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
-      range: { to: { utcOffset: () => 0 } },
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1118,7 +1138,8 @@ describe('processTargetV2', () => {
       dashboardUID: 'unknown_dashboard',
       targets: [],
       panelId: 2,
-      range: { to: { utcOffset: () => 0 } },
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
       app: 'unknown_app',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1141,7 +1162,8 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
-      range: { to: { utcOffset: () => 0 } },
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1174,7 +1196,8 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
-      range: { to: { utcOffset: () => 0 } },
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1207,7 +1230,8 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
-      range: { to: { utcOffset: () => 0 } },
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 
@@ -1242,7 +1266,8 @@ describe('processTargetV2', () => {
       dashboardUID: 'dashboard_1',
       targets: [],
       panelId: 2,
-      range: { to: { utcOffset: () => 0 } },
+      timezone: 'utc',
+      range: { to: dateTime('2026-09-07T08:00:00Z') },
       app: 'app_1',
     } as unknown as DataQueryRequest<PromQuery>;
 

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -201,8 +201,10 @@ export class PrometheusDatasource
       expr: expr,
       queryType: PromQueryType.timeSeriesQuery,
       requestId: request.panelId + target.refId,
-      // We need to pass utcOffsetSec to backend to calculate aligned range
-      utcOffsetSec: this.timeSrv.timeRange().to.utcOffset() * 60,
+      // The backend aligns range queries to the step using the dashboard time zone offset.
+      // request.range is built by Grafana in the dashboard time zone; the plugin's own TimeSrv
+      // copy is never initialised with the dashboard model and would report the browser offset.
+      utcOffsetSec: request.range.to.utcOffset() * 60,
     }
 
     if (target.range && target.instant) {

--- a/src/datasource.tsx
+++ b/src/datasource.tsx
@@ -33,6 +33,7 @@ import {
   DataSourceWithQueryImportSupport,
   dateMath,
   DateTime,
+  dateTimeForTimeZone,
   getDefaultTimeRange,
   LegacyMetricFindQueryOptions,
   QueryFixAction,
@@ -201,10 +202,12 @@ export class PrometheusDatasource
       expr: expr,
       queryType: PromQueryType.timeSeriesQuery,
       requestId: request.panelId + target.refId,
-      // The backend aligns range queries to the step using the dashboard time zone offset.
-      // request.range is built by Grafana in the dashboard time zone; the plugin's own TimeSrv
-      // copy is never initialised with the dashboard model and would report the browser offset.
-      utcOffsetSec: request.range.to.utcOffset() * 60,
+      // The backend aligns range queries to the step using the offset of the request time zone
+      // (dashboard or Explore) at the end of the range, so DST is honoured. request.range.to itself
+      // cannot be used directly: Grafana parses relative ranges in the request time zone but absolute
+      // ones with plain dateTime(), i.e. in the browser time zone. The plugin's own TimeSrv copy is
+      // never initialised with the dashboard model and would report the browser offset as well.
+      utcOffsetSec: dateTimeForTimeZone(request.timezone, request.range.to.valueOf()).utcOffset() * 60,
     }
 
     if (target.range && target.instant) {


### PR DESCRIPTION
Related issue: #539 

### Describe Your Changes

1. align `start` and `end` of range queries to the query step
2. send `start`, `end` and `time` query params as unix milliseconds instead of whole seconds, so zoomed-in graphs with sub-second steps are no longer cut off at the edges

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
