### PR TITLE
build(webpack): keep the lezer-metricsql workspace on its node_modules path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage
 bin/
 dist/
 !packages/lezer-metricsql/dist/
+!packages/lezer-metricsql/dist/**
 victoriametrics-datasource/
 plugins/
 artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## tip
 
+* MAINTENANCE: fix the frontend build of the plugin.
+
 ## v0.26.0
 
 * FEATURE: align `start` and `end` of range queries to the query step. See [#539](https://github.com/VictoriaMetrics/victoriametrics-datasource/issues/539).

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -18,6 +18,16 @@ const config = async (env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
 
   const newConfig = merge(baseConfig, {
+    // `lezer-metricsql` is a workspace package, so `node_modules/lezer-metricsql` is a symlink into
+    // `packages/`. Resolved to its real path, its generated bundle is recorded in `module.js.map` as
+    // `../packages/lezer-metricsql/dist/index.es.js`, and the Grafana plugin validator then treats a
+    // build artifact as plugin source code and byte-compares it against the repository
+    // (`js-map-no-match`). Keeping the symlink path records it under `../node_modules/` instead,
+    // which the validator ignores like every other dependency.
+    resolve: {
+      symlinks: false,
+    },
+
     // update output configuration
     // other configurations stay the same
     output: {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -28,6 +28,15 @@ const config = async (env): Promise<Configuration> => {
       symlinks: false,
     },
 
+    // Everything under `node_modules` is snapshotted as `<name>@<version>` from its package.json,
+    // on the assumption that only a package manager writes there. `lezer-metricsql` is built from
+    // this repository by `yarn build:lezer-metricsql` and its version does not change, so without
+    // this webpack would silently reuse the previously bundled parser after the grammar is
+    // regenerated.
+    snapshot: {
+      unmanagedPaths: [path.resolve(process.cwd(), 'node_modules/lezer-metricsql')],
+    },
+
     // update output configuration
     // other configurations stay the same
     output: {


### PR DESCRIPTION
### Describe Your Changes

- Set `resolve.symlinks: false` so webpack records the bundled `lezer-metricsql` workspace as `../node_modules/lezer-metricsql/...` instead of resolving the symlink to `../packages/...`. A generated build artifact is no longer listed in module.js.map as plugin source code and byte-compared against the repository by the Grafana plugin validator (`js-map-no-match`). This also covers the duplicate `@lezer/*` failure mode that 022727c5 worked around with `resolutions`, which were dropped during the package upgrade in dfc9e8ac.
- Harden the `.gitignore` negation for `packages/lezer-metricsql/dist/` so gitignore matchers that ignore a re-included directory cannot drop the tracked bundle.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
